### PR TITLE
Implemented the custom header name config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "jobilla/deprecated-routes-middleware",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "A Laravel middleware to mark routes/endpoints as deprecated",
     "type": "library",
     "license": "MIT",

--- a/config/deprecated_routes.php
+++ b/config/deprecated_routes.php
@@ -3,6 +3,11 @@
 return [
 
     /*
+     * Custom header name. `null` will use the default name defined in the middleware.
+     */
+    'header_name' => null,
+
+    /*
      * Enabling this option will cause the middleware to dispatch an event every time a deprecated route is visited.
      */
     'fire_event' => true,

--- a/src/Http/Middlewares/DeprecatedRoute.php
+++ b/src/Http/Middlewares/DeprecatedRoute.php
@@ -14,7 +14,7 @@ class DeprecatedRoute
     /**
      * @var string
      */
-    public const HEADER_NAME = 'X-Deprecated-At';
+    public const DEFAULT_HEADER_NAME = 'X-Deprecated-At';
 
     /**
      * Handle an incoming request.
@@ -32,7 +32,7 @@ class DeprecatedRoute
         $this->logDeprecatedRequest($request);
         $this->fireDeprecationEvent($request, $response);
 
-        $response->headers->set(static::HEADER_NAME, $this->getTimestampString($deprecatedAt));
+        $response->headers->set($this->getHeaderName(), $this->getTimestampString($deprecatedAt));
 
         return $response;
     }
@@ -62,6 +62,14 @@ class DeprecatedRoute
         }
 
         Event::dispatch(new RouteIsDeprecated($request, $response));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getHeaderName(): string
+    {
+        return Config::get('deprecated_routes.header_name', static::DEFAULT_HEADER_NAME);
     }
 
     /**

--- a/tests/Http/Middlewares/DeprecatedRouteTest.php
+++ b/tests/Http/Middlewares/DeprecatedRouteTest.php
@@ -31,11 +31,11 @@ class DeprecatedRouteTest extends TestCase
             return $response;
         }, $deprecatedAt);
 
-        $this->assertTrue($response->headers->has(DeprecatedRoute::HEADER_NAME));
+        $this->assertTrue($response->headers->has(DeprecatedRoute::DEFAULT_HEADER_NAME));
 
         $this->assertEquals(
             Carbon::createFromFormat('Y-m-d', $deprecatedAt)->startOfDay()->toIso8601String(),
-            $response->headers->get(DeprecatedRoute::HEADER_NAME)
+            $response->headers->get(DeprecatedRoute::DEFAULT_HEADER_NAME)
         );
     }
 
@@ -124,5 +124,31 @@ class DeprecatedRouteTest extends TestCase
         $middleware->handle($request, function ($request) use ($response) {
             return $response;
         }, $deprecatedAt);
+    }
+
+    /** @test */
+    public function it_should_use_the_config_option_for_header_name()
+    {
+        $middleware = new DeprecatedRoute();
+
+        Config::set('deprecated_routes.log_level', false);
+        Config::set('deprecated_routes.fire_event', false);
+        Config::set('deprecated_routes.header_name', 'This-Endpoint-Is-Discouraged-Since');
+
+        $request = Request::create('/', 'GET');
+        $response = new Response('');
+
+        $deprecatedAt = '2020-10-06';
+
+        $middleware->handle($request, function ($request) use ($response) {
+            return $response;
+        }, $deprecatedAt);
+
+        $this->assertTrue($response->headers->has('This-Endpoint-Is-Discouraged-Since'));
+
+        $this->assertEquals(
+            Carbon::createFromFormat('Y-m-d', $deprecatedAt)->startOfDay()->toIso8601String(),
+            $response->headers->get('This-Endpoint-Is-Discouraged-Since')
+        );
     }
 }


### PR DESCRIPTION
This PR introduces changes to enable consumers of the library to define their own name for the deprecation HTTP header.

Resolves #2 