### PR TITLE
Laravel 9.x Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "nesbot/carbon": "^2.0",
-        "laravel/framework": "^6.0|^7.0|^8.0"
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "9.5.x-dev",


### PR DESCRIPTION
This PR updates the requirement for `laravel/framework` to include `9.0`.